### PR TITLE
add GitHub repo to `gleam.toml`

### DIFF
--- a/gleam.toml
+++ b/gleam.toml
@@ -3,7 +3,7 @@ version = "1.0.0"
 description = "A simple on-disc JSON based data store"
 
 licences = ["Apache-2.0"]
-repository = { type = "github", user = "", repo = "" }
+repository = { type = "github", user = "lpil", repo = "storail" }
 links = [
   { title = "Sponsor", href = "https://github.com/sponsors/lpil" },
 ]


### PR DESCRIPTION
Hi! The repo information is missing from `gleam.toml`.